### PR TITLE
Link <filesystem> lib for GCC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,8 +35,11 @@ add_subdirectory(json)
 
 target_link_libraries(${PROJECT_NAME} application_lib)
 
+# GCC requires explicit linking to the <filesystem> static lib
+if(CMAKE_COMPILER_IS_GNUCXX)
+    target_link_libraries(${PROJECT_NAME} stdc++fs)
+endif()
+
 if(MSVC)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/INCREMENTAL:NO")
 endif()
-
-

--- a/src/fs/CMakeLists.txt
+++ b/src/fs/CMakeLists.txt
@@ -10,3 +10,8 @@ file(GLOB fs_sources
 )
 
 add_library( ${PROJECT_NAME}_lib STATIC ${fs_sources} )
+
+# GCC requires explicit linking to the <filesystem> static lib
+if(CMAKE_COMPILER_IS_GNUCXX)
+    target_link_libraries(${PROJECT_NAME}_lib stdc++fs)
+endif()


### PR DESCRIPTION
GCC requires explicit linking of the <filesystem> lib via `-lstdc++fs`. This patch checks if the compiler is GCC and links it in the main application and in the fs lib.